### PR TITLE
Edit separators to support new output format of flow v0.66.0

### DIFF
--- a/suppressor.js
+++ b/suppressor.js
@@ -2,10 +2,9 @@
 /* eslint-disable no-undef */
 
 const stdoutChunks = [];
-const JOIN_SEPARATOR = "\r\n\u001b[0m\u001b[0m\r\n\u001b[0m"
+const JOIN_SEPARATOR = "\r\n\u001b[0m\u001b[0m\r\n\r\n"
 const SPLIT_SEPARATORS = [
-  "\\r\\n\\u001b\\[0m\\u001b\\[0m\\r\\n\\u001b\\[0m",
-  "\\r\\n\\u001b\\[0m\\u001b\\[0m\\r\\r\\n\\u001b\\[0m",  // double carriage return
+  "\\r\\n\\u001b\\[0m\\u001b\\[0m\\r\\n\\r\\n"
 ]
 
 module.exports = {


### PR DESCRIPTION
Hi!

In recent `flow` releases they changed output format, so current version of `flow-error-suppressor` works incorrectly.

I changed separators to support current version of `flow` (`v0.66.0`).

I'm not sure what that "// double carriage return" separator was for, though, so maybe it should be kept.

Also this fix has no backward compatibility, therefore a note should be added to README to reflect that.